### PR TITLE
Enable docs deployment by updating run condition

### DIFF
--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -42,7 +42,7 @@ jobs:
         name: Deploy built documentation to GitHub pages
         # Only run deploy-docs job on push to main, see GitHub docs:
         # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions
-        if: ${{ github.event_name == 'push' && github.ref == 'main' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         permissions:
             contents: read
             pages: write


### PR DESCRIPTION
The conditional in the deploy-docs task used `github.ref == 'main'`. This job was skipped, according to the [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context) the correct syntax is `github.ref_name`.