### PR TITLE
Updated icon to point to github rather than trac

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,14 +90,7 @@ napoleon_include_special_with_doc = True
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
-    "icon_links": [
-        {
-            "name": "Trac",
-            "url": "https://code.metoffice.gov.uk/trac/ancil",
-            "icon": "fa-solid fa-bugs",
-            "type": "fontawesome",
-        }
-    ],
+    "github_url": "https://github.com/MetOffice/UG-ANTS",
     "show_toc_level": 2,
 }
 


### PR DESCRIPTION
Closes #26.

Change here is modelled on the equivalent ANTS change, MetOffice/ANTS#65.