### PR TITLE
Update _version.py

### DIFF
--- a/lib/ugants/_version.py
+++ b/lib/ugants/_version.py
@@ -4,4 +4,4 @@
 # See LICENSE.txt in the root of the repository for full licensing details.
 """Define the fallback version to be used when UG-ANTS is not installed into an environment."""  # noqa: E501
 
-FALLBACK_VERSION = "0.4.0dev"
+FALLBACK_VERSION = "0.5.0dev"


### PR DESCRIPTION
## Description
Bumps the fallback version to be used when setuptools-scm cannot identify the version.

---

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices)**

-----

### Branch

**Related branches (e.g. UG-Contrib):**
None

**UG-ANTS rose stem logs**
UG-ANTS/run2


**UG-Contrib rose stem logs**
None

-----

### Testing

For core UG-ANTS only tests, the bare minimum that will be accepted is the `--group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `--group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the UG-Contrib tests, pointing at your branch, with `--group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for UG-ANTS `rose stem --group=all` tests
- NA This will this maintain results for UG-Contrib `rose stem --group=all` tests
- NA If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP C896 is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

----

**Approvals for this change**

- [x] I have approval from the UG-ANTS core development team for these changes

------

**New functionality further testing**

- NA If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- NA Unittests have been added
- NA Rose stem tests have been added for any new functionality
- [x] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [x] I have remembered to run the code style check tasks/tools

------

**Other**
- [x] I read the [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [x] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/UG-ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there.
- [x] The ticket labels, milestones, etc. are correct
- [ ] Links to all related tickets have been provided in the ticket description
- [x]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1). | **Josh Rackham** |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#LicencecopyrightandIPR), including appropriate [attribution for usage of Generative AI](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#AIassistanceandattribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | **Josh Rackham** |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `rose stem --group=all` to help ensure all affected configurations has been flagged up.

<div>
Wed 17 Dec 09:45:00 GMT 2025
Git status: 
[
  ""
]
Commit: 
af2787be378e83cf80bc69378f8662d8edb72c24
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | build_docs | succeeded | 
 | ancil_regrid_mesh_to_grid_conservative | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative_tolerance | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear | succeeded | 
 | ancil_regrid_grid_to_mesh_nearest | succeeded | 
 | ancil_split_by_latitude_grid_to_mesh | succeeded | 
 | ancil_regrid_mesh_to_grid_nearest | succeeded | 
 | unittests | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_conservative | succeeded | 
 | black | succeeded | 
 | ancil_split_by_latitude_mesh_to_grid | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_conservative | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_mesh_nearest | succeeded | 
 | ancil_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_nearest | succeeded | 
 | ruff | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_fill_missing_points_with_target_mask | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative | succeeded | 
 | ancil_fill_missing_points_no_target_mask | succeeded | 
 | ancil_ugrid_to_XIOS | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_conservative | succeeded | 
 | ancil_extract_mesh | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_generate_mask_sea | succeeded | 
 | ancil_generate_mask_land | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_bilinear | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_bilinear | succeeded | 
 | ancil_ugrid_to_XIOS_single | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative | succeeded | 
 | rose_ana_extract_mesh | succeeded | 
 | rose_ana_regrid_mesh_to_grid | succeeded | 
 | rose_ana_fill_missing_points | succeeded | 
 | rose_ana_generate_mask | succeeded | 
 | rose_ana_ugrid_to_XIOS | succeeded | 
 | rose_ana_regrid_grid_to_mesh | succeeded | 
 | ancil_band_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_band_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_band_regrid_mesh_to_grid_conservative | succeeded | 
 | rose_ana_regrid_mesh_to_mesh | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_band_regrid_grid_to_mesh_nearest | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | linkcheck | succeeded | 
 | ancil_recombine_grid_bands_bilinear | succeeded | 
 | ancil_recombine_grid_bands_nearest | succeeded | 
 | ancil_recombine_grid_bands_conservative | succeeded | 
 | ancil_recombine_mesh_bands_bilinear | succeeded | 
 | ancil_recombine_mesh_bands_conservative_tolerance | succeeded | 
 | ancil_recombine_mesh_bands_nearest | succeeded | 
 | ancil_recombine_mesh_bands_conservative | succeeded | 
 | ancil_recombine_mesh_bands_bilinear_tolerance | succeeded | 
 | rose_ana_band_regrid_mesh_to_grid | succeeded | 
 | rose_ana_band_regrid_grid_to_mesh | succeeded | 

</div>
<br>
<div>
Add trac_status.log contents for UG-Contrib rose-stem here.
</div>
