### PR TITLE
First draft of instructions files for GitHub Copilot for UG-ANTS.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+<!-- Some of the content of this file has been produced with the assistance of Met Office Github Copilot Enterprise. -->
+
+## Project overview
+
+This project is for the core library for generating ancillary files for LFRic on a UGrid mesh.  It is built on top of iris, and relies on [ANTS](https://github.com/MetOffice/ANTS) for any pre-processing needed on the regular source grid.
+
+Science applications for generating UGrid ancillaries for Momentum may be found in the published [working practices](https://metoffice.github.io/ancil-working-practices) or in the corresponding [repository](https://github.com/MetOffice/ug-ancillary-file-science).
+
+netCDF is the only supported data format.
+
+## Code style
+
+All code should follow the [working practices](https://github.com/MetOffice/ancil-working-practices).
+
+## CLA
+
+All code contributors need to sign the CLA.  Under no circumstances can an AI agent sign the CLA.
+
+## Directory structure
+
+The directory structure is as follows:
+
+```
+bin/ - generic ancillary generation applications.
+docs/ - static documentation and documentation configuration.
+lib/ugants/ - library code for generating UGrid ancillaries.
+lib/ugants/tests/ - unit tests for the library code.
+rose-stem/ - cylc workflow for end to end testing.
+utils/ - infrastructure for the end to end testing.
+```
+
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,12 +21,12 @@ All code contributors need to sign the CLA.  Under no circumstances can an AI ag
 The directory structure is as follows:
 
 ```
-bin/ - generic ancillary generation applications.
-docs/ - static documentation and documentation configuration.
-lib/ugants/ - library code for generating UGrid ancillaries.
-lib/ugants/tests/ - unit tests for the library code.
+bin/ - generic ancillary generation applications in python.
+docs/ - static documentation and documentation configuration in rst.
+lib/ugants/ - library code for generating UGrid ancillaries in python.
+lib/ugants/tests/ - unit tests for the library code in python following pytest style.
 rose-stem/ - cylc workflow for end to end testing.
-utils/ - infrastructure for the end to end testing.
+utils/ - infrastructure for the end to end testing in python.
 ```
 
 

--- a/.github/instructions/CLA.instructions.md
+++ b/.github/instructions/CLA.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "**/CONTRIBUTING.rst"
+---
+
+Under no circumstances can CONTRIBUTING.rst be edited by an AI agent or LLM.  This file is for human contributors to the project, and contains instructions for how to contribute.  It also contains the CLA, which must be signed by all human contributors before they can contribute code to the project.
+
+<!-- From https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions?tool=visualstudio#creating-path-specific-custom-instructions-2 -->


### PR DESCRIPTION
Some of the content of this commit has been produced with the assistance of Met Office Github Copilot Enterprise.

No issue for this - if you would like an issue, I can create one.

This adds some guidance for taming github copilot a little bit.  Note that it doesn't provide complete protection for the CLA, since user instructions override the repo instructions (see https://code.visualstudio.com/docs/copilot/customization/custom-instructions#_instruction-priority for more details).  It's also intentionally a light touch - the assumption is that this will be iterated in future.

Because of that assumption, this does imply a maintanence burden for the MIAO team in future: if you would rather not take that burden, feel free to reject this outright.

There is a side effect of also providing some useful context for human readers.  Although this context is hidden enough that I don't know if that benefit will be realised.

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**Related branches (e.g. ug-ancillary-file-science):**<br>
N/A

**UG-ANTS rose stem logs** <br>
ugants_instructions/run1 <br>
-----

### Testing

For core UG-ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the ug-ancillary-file-science tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [X] This will maintain results for UG-ANTS `cylc vip ./rose-stem -z group=all` tests
- [X] This will this maintain results for ug-ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [N/A ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP C896 is expected to have been tested
- [N/A ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [N/A ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [X] I have approval from the UG-ANTS core development team for these changes

------

**New functionality further testing**

- [N/A ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [N/A ] Unittests have been added
- [N/A ] Rose stem tests have been added for any new functionality
- [X] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [X] I have remembered to run the code style check tasks/tools


------

**Other**
- [X] I have read the [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [X] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/UG-ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [X] The ticket labels, milestones, etc. are correct
- [N/A] Links to all related tickets have been provided in the ticket description
- [X]  I have requested a code reviewer
- [N/A ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)). | Harold Dyson |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | Harold Dyson |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>
GitHub copilot was used to draft some of the text in the `copilot-instructions.md` file (notably, the "Overview" paragraphs are very similar to the original copilot version).
--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

<div>
Add workflow_status.log contents for UG-ANTS rose-stem here.

Fri 27 Mar 14:42:50 GMT 2026
Git status: 
[
  ""
]
Commit: 
49a4b46690e1c48a2031c6f959455d398b6807e7
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | failed | 1 | 
 | succeeded | 64 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_regrid_mesh_to_mesh_nearest | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_bilinear | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_nearest | succeeded | 
 | ancil_ugrid_to_XIOS | succeeded | 
 | build_docs | succeeded | 
 | ancil_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_conservative | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear | succeeded | 
 | black | succeeded | 
 | unittests | succeeded | 
 | ancil_split_by_latitude_mesh_to_grid | succeeded | 
 | ancil_regrid_grid_to_mesh_nearest | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative_tolerance | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_ugrid_to_XIOS_single | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_bilinear | succeeded | 
 | ancil_fill_missing_points_no_target_mask | succeeded | 
 | ancil_split_by_latitude_grid_to_mesh | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_generate_mask_sea | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_nearest | succeeded | 
 | ancil_generate_mask_land | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_nearest | succeeded | 
 | ancil_fill_missing_points_with_target_mask | succeeded | 
 | ancil_regrid_mesh_to_grid_conservative | succeeded | 
 | ancil_extract_mesh | succeeded | 
 | ruff | succeeded | 
 | rose_ana_ugrid_to_XIOS | succeeded | 
 | rose_ana_generate_mask | succeeded | 
 | rose_ana_regrid_mesh_to_grid | succeeded | 
 | rose_ana_regrid_grid_to_mesh | succeeded | 
 | rose_ana_extract_mesh | succeeded | 
 | rose_ana_fill_missing_points | succeeded | 
 | rose_ana_regrid_mesh_to_mesh | succeeded | 
 | ancil_band_regrid_mesh_to_grid_conservative | succeeded | 
 | ancil_band_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_band_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_band_regrid_grid_to_mesh_nearest | succeeded | 
 | linkcheck | failed | 
 | ancil_recombine_grid_bands_conservative | succeeded | 
 | ancil_recombine_grid_bands_bilinear | succeeded | 
 | ancil_recombine_grid_bands_nearest | succeeded | 
 | ancil_recombine_mesh_bands_nearest | succeeded | 
 | ancil_recombine_mesh_bands_conservative | succeeded | 
 | ancil_recombine_mesh_bands_bilinear | succeeded | 
 | ancil_recombine_mesh_bands_conservative_tolerance | succeeded | 
 | ancil_recombine_mesh_bands_bilinear_tolerance | succeeded | 
 | rose_ana_band_regrid_mesh_to_grid | succeeded | 
 | rose_ana_band_regrid_grid_to_mesh | succeeded | 

</div>
<br>
<div>
Add trac_status.log contents for ug-ancillary-file-science rose-stem here.
</div>
N/A