### PR TITLE
Add io.load.ugrid_cube for loading a single cube.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -288,3 +288,4 @@ Contributor Licence Agreement:
 * Josh Rackham (Met Office)
 * Andrew Clark (Met Office)
 * Theo Geddes (Met Office)
+* Jennifer Hickson (Met Office)

--- a/lib/ugants/io/load.py
+++ b/lib/ugants/io/load.py
@@ -66,7 +66,8 @@ def ugrid(uris, constraints=None) -> iris.cube.CubeList:
 
     return ugrid_cubelist
 
-def ugrid_cube(uris, constraints=None) -> iris.cube.Cube:
+
+def ugrid_cube(uris, constraint=None) -> iris.cube.Cube:
     """Load a UGrid file. Will not load if the file contains regular data.
 
     Parameters
@@ -95,7 +96,7 @@ def ugrid_cube(uris, constraints=None) -> iris.cube.Cube:
     """
     with PARSE_UGRID_ON_LOAD.context():
         cube = iris.load_cube(
-            uris, constraints=constraints, callback=_check_for_non_ugrid
+            uris, constraint=constraint, callback=_check_for_non_ugrid
         )
 
     # By constraining on a horizontal (unstructured) dimension, iris attempts to
@@ -104,12 +105,11 @@ def ugrid_cube(uris, constraints=None) -> iris.cube.Cube:
     if not is_ugrid(cube):
         raise iris.exceptions.InvalidCubeError(
             f"Attempting to load UGrid data from '{uris}' with constraint(s) "
-            f"'{constraints}' has resulted in non-UGrid data being loaded. "
+            f"'{constraint}' has resulted in non-UGrid data being loaded. "
             "This may be caused by constraining on an unstructured dimension."
         )
 
     return cube
-
 
 
 def _check_for_non_ugrid(cube: iris.cube.Cube, field, filename):

--- a/lib/ugants/io/load.py
+++ b/lib/ugants/io/load.py
@@ -66,6 +66,51 @@ def ugrid(uris, constraints=None) -> iris.cube.CubeList:
 
     return ugrid_cubelist
 
+def ugrid_cube(uris, constraints=None) -> iris.cube.Cube:
+    """Load a UGrid file. Will not load if the file contains regular data.
+
+    Parameters
+    ----------
+    uris : Any
+        Location of file to load. Must be a NetCDF file.
+    constraints: Any | None
+        One iris constraint. The constraint can be either a string,
+        or an instance of :class:`iris.Constraint`. If the constraint is a string
+        it will be used to match against cube.name().
+
+    Returns
+    -------
+    iris.cube.Cube
+        A single iris :class:`iris.cube.Cube` containing the loaded data.
+
+    Raises
+    ------
+    iris.exceptions.InvalidCubeError
+        If the specified file does not contain UGrid data.
+    iris.exceptions.InvalidCubeError
+        If no data can be found which matches the provided constraint(s).
+    iris.exceptions.InvalidCubeError
+        If a mesh has been removed from a cube during constrained load.
+        This may be caused by constraining on an unstructured dimension.
+    """
+    with PARSE_UGRID_ON_LOAD.context():
+        cube = iris.load_cube(
+            uris, constraints=constraints, callback=_check_for_non_ugrid
+        )
+
+    # By constraining on a horizontal (unstructured) dimension, iris attempts to
+    # subset a MeshCoord. This causes the MeshCoords to be converted to AuxCoords,
+    # so the resulting cube has no mesh. This will result in non-ugrid data.
+    if not is_ugrid(cube):
+        raise iris.exceptions.InvalidCubeError(
+            f"Attempting to load UGrid data from '{uris}' with constraint(s) "
+            f"'{constraints}' has resulted in non-UGrid data being loaded. "
+            "This may be caused by constraining on an unstructured dimension."
+        )
+
+    return cube
+
+
 
 def _check_for_non_ugrid(cube: iris.cube.Cube, field, filename):
     """Check if the loaded data is UGrid or not.

--- a/lib/ugants/io/load.py
+++ b/lib/ugants/io/load.py
@@ -94,22 +94,16 @@ def ugrid_cube(uris, constraint=None) -> iris.cube.Cube:
         If a mesh has been removed from a cube during constrained load.
         This may be caused by constraining on an unstructured dimension.
     """
-    with PARSE_UGRID_ON_LOAD.context():
-        cube = iris.load_cube(
-            uris, constraint=constraint, callback=_check_for_non_ugrid
-        )
+    cubelist = ugrid(uris, constraint)
 
-    # By constraining on a horizontal (unstructured) dimension, iris attempts to
-    # subset a MeshCoord. This causes the MeshCoords to be converted to AuxCoords,
-    # so the resulting cube has no mesh. This will result in non-ugrid data.
-    if not is_ugrid(cube):
-        raise iris.exceptions.InvalidCubeError(
-            f"Attempting to load UGrid data from '{uris}' with constraint(s) "
-            f"'{constraint}' has resulted in non-UGrid data being loaded. "
-            "This may be caused by constraining on an unstructured dimension."
+    if len(cubelist) == 1:
+        return cubelist[0]
+    else:
+        raise (
+            iris.exceptions.InvalidCubeError(
+                f"Data found in file(s) '{uris}' contains more than one cube."
+            )
         )
-
-    return cube
 
 
 def _check_for_non_ugrid(cube: iris.cube.Cube, field, filename):

--- a/lib/ugants/regrid/applications.py
+++ b/lib/ugants/regrid/applications.py
@@ -144,7 +144,7 @@ class SplitMeshToGridByLatitude(Application):
     """The output **directory** to which to write the :attr:`source_bands` and
     :attr:`target_bands`."""
 
-    # TODO: https://github.com/MetOffice/UG-ANTS/issues/43
+    # TODO: https://github.com/MetOffice/UG-ANTS/issues/90
     #  Replace with a central load cube when that is available.
     _loader = _load_any_cubes
 

--- a/lib/ugants/tests/io/load/test_ugrid_cube.py
+++ b/lib/ugants/tests/io/load/test_ugrid_cube.py
@@ -1,0 +1,62 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of UG-ANTS and is released under the BSD 3-Clause license.
+# See LICENSE.txt in the root of the repository for full licensing details.
+from tempfile import NamedTemporaryFile
+
+import iris.exceptions
+import pytest
+from iris import Constraint
+from iris.coords import DimCoord
+from iris.cube import Cube, CubeList
+
+from ugants.io import save
+from ugants.io.load import ugrid_cube
+from ugants.tests import get_data_path
+
+
+def test_ugrid_sample_load():
+    ugrid_sample = ugrid_cube(get_data_path("data_C4.nc"), "sample_data")
+    assert isinstance(ugrid_sample, Cube)
+
+
+def test_ugrid_cubelist():
+    with pytest.raises(
+        iris.exceptions.ConstraintMismatchError,
+        match="failed to merge into a single cube",
+    ):
+        ugrid_cube(get_data_path("data_C4.nc"))
+
+
+def test_non_ugrid_sample_load():
+    with pytest.raises(
+        iris.exceptions.InvalidCubeError,
+        match="Specified file '.*/non_ugrid_data.nc' does not contain UGrid data",
+    ):
+        ugrid_cube(get_data_path("non_ugrid_data.nc"), "sample_data")
+
+
+def test_cube_not_found():
+    with pytest.raises(
+        iris.exceptions.ConstraintMismatchError,
+        match="no cubes found",
+    ):
+        ugrid_cube(get_data_path("data_C4.nc"), constraint="no_data_constraint")
+
+
+def test_ugrid_load_coordinate_constraint():
+    sample_cube = ugrid_cube(get_data_path("data_C4.nc"), "sample_data")
+    sample_cube_second_level = sample_cube.copy()
+    vertical_levels = DimCoord([0, 1], "height")
+    sample_cube.add_aux_coord(vertical_levels[0])
+    sample_cube_second_level.add_aux_coord(vertical_levels[1])
+    multi_dim_cube = CubeList([sample_cube, sample_cube_second_level]).merge()[0]
+    temporary_file = NamedTemporaryFile(suffix=".nc")
+    save.ugrid(multi_dim_cube, temporary_file.name)
+
+    height_constraint = Constraint(height=1)
+    constrained_loaded_cube = ugrid_cube(
+        temporary_file.name, constraint=height_constraint
+    )
+    assert isinstance(constrained_loaded_cube, Cube)
+    assert constrained_loaded_cube.coord("height").points == vertical_levels[1].points

--- a/lib/ugants/tests/io/load/test_ugrid_cube.py
+++ b/lib/ugants/tests/io/load/test_ugrid_cube.py
@@ -22,8 +22,8 @@ def test_ugrid_sample_load():
 
 def test_ugrid_cubelist():
     with pytest.raises(
-        iris.exceptions.ConstraintMismatchError,
-        match="failed to merge into a single cube",
+        iris.exceptions.InvalidCubeError,
+        match="contains more than one cube",
     ):
         ugrid_cube(get_data_path("data_C4.nc"))
 
@@ -38,8 +38,9 @@ def test_non_ugrid_sample_load():
 
 def test_cube_not_found():
     with pytest.raises(
-        iris.exceptions.ConstraintMismatchError,
-        match="no cubes found",
+        iris.exceptions.InvalidCubeError,
+        match=r"No data found in file\(s\) '.*/data_C4.nc' matching the "
+        r"provided constraint\(s\) 'no_data_constraint'.",
     ):
         ugrid_cube(get_data_path("data_C4.nc"), constraint="no_data_constraint")
 


### PR DESCRIPTION
Closes #43

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**Related branches (e.g. ug-ancillary-file-science):**<br>
[please link any related branches here]

**UG-ANTS rose stem logs** <br>
[https://cylchub/services/cylc-review/cycles/jennifer.hickson/?suite=ugants_43%2Frun2](ugants_43/run2) <br>


**ug-ancillary-file-science rose stem logs** <br>
[https://cylchub/services/cylc-review/cycles/jennifer.hickson/?suite=ug_ancil_sci_43%2Frun3](ug_ancil_sci_43/run3) <br>

-----

### Testing

For core UG-ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the ug-ancillary-file-science tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for UG-ANTS `cylc vip ./rose-stem -z group=all` tests
- [x] This will this maintain results for ug-ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [ ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP C896 is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [x] I have approval from the UG-ANTS core development team for these changes

------

**New functionality further testing**

- [ ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [x] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [ ] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [x] I have remembered to run the code style check tasks/tools


<div>
Unrelated linkcheck failure in rose-stem. 
</div>

------

**Other**
- [x] I have read the [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [x] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/UG-ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [ ] The ticket labels, milestones, etc. are correct
- [x] Links to all related tickets have been provided in the ticket description
- [ ]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)). | Jenny Hickson |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | Jenny Hickson |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

<div>
Tue  7 Apr 10:30:32 BST 2026
Git status: 
[
  "?? ../.idea/"
]
Commit: 
05c159dff34c452e7736fa030e026948d1765c50
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | failed | 1 | 
 | succeeded | 64 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_ugrid_to_XIOS | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_bilinear | succeeded | 
 | ancil_fill_missing_points_with_target_mask | succeeded | 
 | build_docs | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_conservative | succeeded | 
 | black | succeeded | 
 | ancil_split_by_latitude_grid_to_mesh | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_conservative | succeeded | 
 | ancil_ugrid_to_XIOS_single | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_conservative | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_conservative | succeeded | 
 | ancil_generate_mask_sea | succeeded | 
 | ruff | succeeded | 
 | ancil_regrid_mesh_to_mesh_nearest | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_nearest | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_nearest | succeeded | 
 | ancil_split_by_latitude_mesh_to_grid | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative_tolerance | succeeded | 
 | ancil_extract_mesh | succeeded | 
 | ancil_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear | succeeded | 
 | ancil_fill_missing_points_no_target_mask | succeeded | 
 | ancil_generate_mask_land | succeeded | 
 | unittests | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_bilinear | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | rose_ana_ugrid_to_XIOS | succeeded | 
 | rose_ana_generate_mask | succeeded | 
 | rose_ana_regrid_grid_to_mesh | succeeded | 
 | rose_ana_regrid_mesh_to_grid | succeeded | 
 | rose_ana_extract_mesh | succeeded | 
 | rose_ana_fill_missing_points | succeeded | 
 | rose_ana_regrid_mesh_to_mesh | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_band_regrid_grid_to_mesh_nearest | succeeded | 
 | ancil_band_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_band_regrid_mesh_to_grid_conservative | succeeded | 
 | ancil_band_regrid_mesh_to_grid_bilinear | succeeded | 
 | linkcheck | failed | 
 | ancil_recombine_mesh_bands_nearest | succeeded | 
 | ancil_recombine_mesh_bands_bilinear_tolerance | succeeded | 
 | ancil_recombine_mesh_bands_bilinear | succeeded | 
 | ancil_recombine_mesh_bands_conservative | succeeded | 
 | ancil_recombine_grid_bands_nearest | succeeded | 
 | ancil_recombine_grid_bands_bilinear | succeeded | 
 | ancil_recombine_mesh_bands_conservative_tolerance | succeeded | 
 | ancil_recombine_grid_bands_conservative | succeeded | 
 | rose_ana_band_regrid_mesh_to_grid | succeeded | 
 | rose_ana_band_regrid_grid_to_mesh | succeeded | 

</div>
<br>
<div>
Tue  7 Apr 10:18:54 BST 2026
Git status: 
[
  " M app/install_cold/rose-app.conf",
  "?? ../.idea/"
]
Commit: 
e9a7eb896497bb2645d8bb8589a7447313c6e006
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 41 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | canopy_heights_unittests | succeeded | 
 | ancil_add_zeroth_level | succeeded | 
 | ancil_lai | succeeded | 
 | subgrid_orography_unittests | succeeded | 
 | ancil_apply_mask_invert | succeeded | 
 | soil_params_unittests | succeeded | 
 | ancil_lct_unittests | succeeded | 
 | ancil_subgrid_orography | succeeded | 
 | black | succeeded | 
 | add_lakes_unittests | succeeded | 
 | ruff | succeeded | 
 | ancil_soils_hydrology_dominant_parameters | succeeded | 
 | ancil_regrid_zonal_mean | succeeded | 
 | ancil_lct | succeeded | 
 | ancil_example | succeeded | 
 | ancil_soil_dust | succeeded | 
 | add_zeroth_level_unittests | succeeded | 
 | ancil_apply_mask_replacezero | succeeded | 
 | ancil_apply_mask_default | succeeded | 
 | lai_unittests | succeeded | 
 | ancil_canopy_heights | succeeded | 
 | regrid_zonal_mean_unittests | succeeded | 
 | apply_mask_unittests | succeeded | 
 | ostia2nwp_unittests | succeeded | 
 | example_unittests | succeeded | 
 | soil_dust_unittests | succeeded | 
 | build_docs | succeeded | 
 | rose_ana_apply_mask | succeeded | 
 | rose_ana_example | succeeded | 
 | rose_ana_add_zeroth_level | succeeded | 
 | rose_ana_canopy_heights | succeeded | 
 | rose_ana_subgrid_orography | succeeded | 
 | rose_ana_regrid_zonal_mean | succeeded | 
 | rose_ana_ancil_lct | succeeded | 
 | rose_ana_lai | succeeded | 
 | rose_ana_soil_dust | succeeded | 
 | ancil_soils_hydrology_average_parameters | succeeded | 
 | linkcheck | succeeded | 
 | ancil_soils_hydrology_make_consistent | succeeded | 
 | rose_ana_soil_params | succeeded | 

</div>
