### PR TITLE
Add ignore ancillary file science links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ linkcheck_anchors_ignore_for_url = ("https://semver.org/",)
 linkcheck_ignore = [
     r"https://github.com/MetOffice/UG-ANTS.*",
     r"https://github.com/MetOffice/tcd-XIOS2-extras.*",
-    r"https://github.com/MetOffice/ug-ancillary-file-science/*",
+    r"https://github.com/MetOffice/ug-ancillary-file-science.*",
 ]
 
 # Napoleon config

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,7 @@ linkcheck_anchors_ignore_for_url = ("https://semver.org/",)
 linkcheck_ignore = [
     r"https://github.com/MetOffice/UG-ANTS.*",
     r"https://github.com/MetOffice/tcd-XIOS2-extras.*",
+    r"https://github.com/MetOffice/ug-ancillary-file-science/*",
 ]
 
 # Napoleon config


### PR DESCRIPTION
Closes N/A

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**UG-ANTS rose stem logs** <br>
dev-ug-ants/run18 <br>


-----

### Testing

For core UG-ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the ug-ancillary-file-science tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for UG-ANTS `cylc vip ./rose-stem -z group=all` tests
- [x] This will this maintain results for ug-ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [ ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP C896 is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [x] I have approval from the UG-ANTS core development team for these changes

------

**New functionality further testing**

- [ ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [ ] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [x] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [x] I have remembered to run the code style check tasks/tools


<div>
Add details of any further testing here.
</div>

------

**Other**
- [x] I have read the [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [ ] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/UG-ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [ ] The ticket labels, milestones, etc. are correct
- [x] Links to all related tickets have been provided in the ticket description
- [x]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/UG-ANTS/contributing.html#contributor-licence-agreement-v1-1)). | **Theo Geddes** |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | **Theo Geddes** |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

<div>
Tue  7 Apr 11:01:12 BST 2026
Git status: 
[
  " M ../docs/source/conf.py",
  "?? ../cubey.nc"
]
Commit: 
33dc518c5cb8756ca88085c7dc701a6306def9b7
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_regrid_mesh_to_grid_conservative | succeeded | 
 | ancil_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_split_by_latitude_mesh_to_grid | succeeded | 
 | ancil_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_bilinear | succeeded | 
 | black | succeeded | 
 | ancil_ugrid_to_XIOS_single | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative_tolerance | succeeded | 
 | ancil_regrid_grid_to_mesh_nearest | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_bilinear | succeeded | 
 | ancil_split_by_latitude_grid_to_mesh | succeeded | 
 | ancil_regrid_grid_to_mesh_output_weights_bilinear | succeeded | 
 | ancil_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_regrid_mesh_to_mesh_nearest | succeeded | 
 | ancil_regrid_mesh_to_mesh_conservative | succeeded | 
 | ancil_generate_mask_sea | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_conservative | succeeded | 
 | ancil_extract_mesh | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear | succeeded | 
 | ancil_regrid_mesh_to_mesh_bilinear_tolerance | succeeded | 
 | build_docs | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_nearest | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_ugrid_to_XIOS | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_nearest | succeeded | 
 | ancil_fill_missing_points_no_target_mask | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_nearest | succeeded | 
 | ancil_fill_missing_points_with_target_mask | succeeded | 
 | unittests | succeeded | 
 | ancil_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_regrid_grid_to_mesh_use_input_weights_conservative | succeeded | 
 | ruff | succeeded | 
 | ancil_generate_mask_land | succeeded | 
 | ancil_regrid_mesh_to_grid_use_input_weights_bilinear | succeeded | 
 | ancil_regrid_mesh_to_grid_output_weights_conservative | succeeded | 
 | rose_ana_fill_missing_points | succeeded | 
 | rose_ana_extract_mesh | succeeded | 
 | rose_ana_generate_mask | succeeded | 
 | rose_ana_regrid_grid_to_mesh | succeeded | 
 | rose_ana_regrid_mesh_to_grid | succeeded | 
 | rose_ana_ugrid_to_XIOS | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative | succeeded | 
 | ancil_band_regrid_grid_to_mesh_bilinear | succeeded | 
 | ancil_band_regrid_grid_to_mesh_conservative_tolerance | succeeded | 
 | ancil_band_regrid_grid_to_mesh_nearest | succeeded | 
 | rose_ana_regrid_mesh_to_mesh | succeeded | 
 | ancil_band_regrid_mesh_to_grid_nearest | succeeded | 
 | ancil_band_regrid_mesh_to_grid_conservative | succeeded | 
 | ancil_band_regrid_mesh_to_grid_bilinear | succeeded | 
 | ancil_recombine_mesh_bands_conservative | succeeded | 
 | ancil_recombine_mesh_bands_bilinear | succeeded | 
 | ancil_recombine_mesh_bands_nearest | succeeded | 
 | ancil_recombine_mesh_bands_bilinear_tolerance | succeeded | 
 | ancil_recombine_mesh_bands_conservative_tolerance | succeeded | 
 | ancil_recombine_grid_bands_nearest | succeeded | 
 | linkcheck | succeeded | 
 | ancil_recombine_grid_bands_conservative | succeeded | 
 | ancil_recombine_grid_bands_bilinear | succeeded | 
 | rose_ana_band_regrid_mesh_to_grid | succeeded | 
 | rose_ana_band_regrid_grid_to_mesh | succeeded | 

</div>
<br>